### PR TITLE
Allowing the passing of the 'queue' option to manualy route tasks

### DIFF
--- a/celery.js
+++ b/celery.js
@@ -160,7 +160,7 @@ function Task(client, name, options, exchange) {
     self.publish = function (args, kwargs, options, callback) {
         var id = options.id || uuid.v4();
 
-        queue = self.options.queue || queue || self.client.conf.DEFAULT_QUEUE;
+        queue = options.queue || self.options.queue || queue || self.client.conf.DEFAULT_QUEUE;
         var msg = createMessage(self.name, args, kwargs, options, id);
         var pubOptions = {
             'contentType': 'application/json',


### PR DESCRIPTION
If calling a task with `{ queue: 'whatever' }` as the options object, the manual queue routing was never being passed through to RabbitMQ. This seems to fix that!
